### PR TITLE
[FIX] GET function name

### DIFF
--- a/sobit_pro_library/include/sobit_pro_library/sobit_pro_joint_action_server.hpp
+++ b/sobit_pro_library/include/sobit_pro_library/sobit_pro_joint_action_server.hpp
@@ -4,8 +4,8 @@
 #include "sobits_interfaces/action/move_to_pose.hpp"
 // #include "sobits_interfaces/action/move_hand_to_target_coord.hpp"
 // #include "sobits_interfaces/action/move_hand_to_target_tf.hpp"
-#include "sobits_interfaces/srv/move_hand_to_target_coord.hpp"
-#include "sobits_interfaces/srv/move_hand_to_target_tf.hpp"
+#include "sobits_interfaces/srv/get_hand_to_target_coord.hpp"
+#include "sobits_interfaces/srv/get_hand_to_target_tf.hpp"
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
@@ -83,8 +83,8 @@ public:
   using MoveToPose = sobits_interfaces::action::MoveToPose;
   // using MoveHandToTargetCoord = sobits_interfaces::action::MoveHandToTargetCoord;
   // using MoveHandToTargetTF = sobits_interfaces::action::MoveHandToTargetTF;
-  using MoveHandToTargetCoord = sobits_interfaces::srv::MoveHandToTargetCoord;
-  using MoveHandToTargetTF = sobits_interfaces::srv::MoveHandToTargetTF;
+  using GetHandToTargetCoord = sobits_interfaces::srv::GetHandToTargetCoord;
+  using GetHandToTargetTF = sobits_interfaces::srv::GetHandToTargetTF;
 
   using GoalHandleMoveJoints = rclcpp_action::ServerGoalHandle<sobits_interfaces::action::MoveJoint>;
   using GoalHandleMoveToPose = rclcpp_action::ServerGoalHandle<sobits_interfaces::action::MoveToPose>;
@@ -143,8 +143,8 @@ private:
 
   rclcpp_action::Server<MoveJoint>::SharedPtr action_server_move_joints_;
   rclcpp_action::Server<MoveToPose>::SharedPtr action_server_move_to_pose_;
-  rclcpp::Service<MoveHandToTargetCoord>::SharedPtr service_server_move_hand_to_coord_;
-  rclcpp::Service<MoveHandToTargetTF>::SharedPtr service_server_move_hand_to_tf_;
+  rclcpp::Service<GetHandToTargetCoord>::SharedPtr service_server_get_hand_to_coord_;
+  rclcpp::Service<GetHandToTargetTF>::SharedPtr service_server_get_hand_to_tf_;
 
   rclcpp_action::GoalResponse handle_move_joints_goal(const rclcpp_action::GoalUUID & uuid, std::shared_ptr<const MoveJoint::Goal> goal);
   rclcpp_action::GoalResponse handle_move_to_pose_goal(const rclcpp_action::GoalUUID & uuid, std::shared_ptr<const MoveToPose::Goal> goal);
@@ -157,8 +157,8 @@ private:
 
   void exe_move_joints(const std::shared_ptr<GoalHandleMoveJoints> goal_handle);
   void exe_move_to_pose(const std::shared_ptr<GoalHandleMoveToPose> goal_handle);
-  void serve_move_hand_to_coord(const std::shared_ptr<MoveHandToTargetCoord::Request> request, std::shared_ptr<MoveHandToTargetCoord::Response> response);
-  void serve_move_hand_to_tf(const std::shared_ptr<MoveHandToTargetTF::Request> request, std::shared_ptr<MoveHandToTargetTF::Response> response);
+  void serve_get_hand_to_coord(const std::shared_ptr<GetHandToTargetCoord::Request> request, std::shared_ptr<GetHandToTargetCoord::Response> response);
+  void serve_get_hand_to_tf(const std::shared_ptr<GetHandToTargetTF::Request> request, std::shared_ptr<GetHandToTargetTF::Response> response);
 
   rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr pub_joint_control_;
   rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr pub_head_joint_control_;

--- a/sobit_pro_library/src/sobit_pro_joint_action_server.cpp
+++ b/sobit_pro_library/src/sobit_pro_joint_action_server.cpp
@@ -27,12 +27,12 @@ JointActionServer::JointActionServer(const rclcpp::NodeOptions & options = rclcp
       std::bind(&JointActionServer::handle_move_to_pose_goal, this, std::placeholders::_1, std::placeholders::_2),
       std::bind(&JointActionServer::handle_move_to_pose_cancel, this, std::placeholders::_1),
       std::bind(&JointActionServer::handle_move_to_pose_accepted, this, std::placeholders::_1));
-  this->service_server_move_hand_to_coord_ = this->create_service<MoveHandToTargetCoord>(
-      "move_hand_to_coord",
-      std::bind(&JointActionServer::serve_move_hand_to_coord, this, std::placeholders::_1, std::placeholders::_2));
-  this->service_server_move_hand_to_tf_ = this->create_service<MoveHandToTargetTF>(
-      "move_hand_to_tf",
-      std::bind(&JointActionServer::serve_move_hand_to_tf, this, std::placeholders::_1, std::placeholders::_2));
+  this->service_server_get_hand_to_coord_ = this->create_service<GetHandToTargetCoord>(
+      "get_hand_to_coord",
+      std::bind(&JointActionServer::serve_get_hand_to_coord, this, std::placeholders::_1, std::placeholders::_2));
+  this->service_server_get_hand_to_tf_ = this->create_service<GetHandToTargetTF>(
+      "get_hand_to_tf",
+      std::bind(&JointActionServer::serve_get_hand_to_tf, this, std::placeholders::_1, std::placeholders::_2));
 
   this->sub_joint_state_ = this->create_subscription<sensor_msgs::msg::JointState>(
       "joint_states", qos_profile, std::bind(&JointActionServer::joint_state_callback, this, std::placeholders::_1));
@@ -405,9 +405,9 @@ void JointActionServer::exe_move_to_pose(
   goal_handle->succeed(result);
 }
 
-void JointActionServer::serve_move_hand_to_coord(
-  const std::shared_ptr<MoveHandToTargetCoord::Request> request,
-  std::shared_ptr<MoveHandToTargetCoord::Response> response)
+void JointActionServer::serve_get_hand_to_coord(
+  const std::shared_ptr<GetHandToTargetCoord::Request> request,
+  std::shared_ptr<GetHandToTargetCoord::Response> response)
 {
 
   // Get namespace
@@ -478,9 +478,9 @@ void JointActionServer::serve_move_hand_to_coord(
   return;
 }
 
-void JointActionServer::serve_move_hand_to_tf(
-  const std::shared_ptr<MoveHandToTargetTF::Request> request,
-  std::shared_ptr<MoveHandToTargetTF::Response> response)
+void JointActionServer::serve_get_hand_to_tf(
+  const std::shared_ptr<GetHandToTargetTF::Request> request,
+  std::shared_ptr<GetHandToTargetTF::Response> response)
 {
 
   // Get namespace


### PR DESCRIPTION
Renamed the function from move_hand_to_target_coord to get_hand_to_target_coord because the function does not perform any motion. Instead, it computes and returns the joint values required to move the hand to the target coordinate.